### PR TITLE
test: Add tests for README example

### DIFF
--- a/sources/eff.js
+++ b/sources/eff.js
@@ -85,14 +85,14 @@ Eff.prototype.chain = function(nextContinuation) {
 // Interpreting and Running
 // -----------------------------------------------------------------------------
 
-export const run = (...interpreters: Array<Function>) => (
-	callback: Function,
-) => (effectfulMonad: EffMonad) =>
+export const run = (interpreters: Array<Function>) => (callback: Function) => (
+	effectfulMonad: EffMonad,
+) =>
 	interpreters.reduce(
 		(previousInterpreter, currentInterpreter) =>
 			currentInterpreter({
 				interpreterContinuation: previousInterpreter,
-				interpreterRestart: x => run(...interpreters)(callback)(x),
+				interpreterRestart: x => run(interpreters)(callback)(x),
 			}),
 		finalMonad =>
 			finalMonad.cata({

--- a/sources/fileSystem.js
+++ b/sources/fileSystem.js
@@ -13,8 +13,7 @@ const FileSystem = taggedSum("FileSystem", {
 });
 
 export const readFile = (path: string) => send(FileSystem.readFile(path));
-export const writeFile = (
-	path: string,
+export const writeFile = (path: string) => (
 	content: string | Buffer | $TypedArray | DataView,
 ) => send(FileSystem.writeFile(path, content));
 

--- a/sources/fileSystem.test.js
+++ b/sources/fileSystem.test.js
@@ -25,7 +25,7 @@ test.cb("Local File System – Read file", t => {
 		fs.writeFile(path.resolve(directory, fileName), a, {}, err => {
 			t.is(null, err);
 
-			run(interpretLocalFileSystem(directory))(b => {
+			run([interpretLocalFileSystem(directory)])(b => {
 				t.is(a, b);
 				t.end();
 			})(application);
@@ -37,12 +37,12 @@ test.cb("Local File System – Write file", t => {
 	const a = "Hello, World! I'm writing!";
 	const fileName = "./helloWorldWriting.txt";
 
-	const application = writeFile(fileName, a);
+	const application = writeFile(fileName)(a);
 
 	tempDirectory((err, directory) => {
 		t.is(null, err);
 
-		run(interpretLocalFileSystem(directory))(() => {
+		run([interpretLocalFileSystem(directory)])(() => {
 			fs.readFile(path.resolve(directory, fileName), "utf8", (err, b) => {
 				t.is(null, err);
 
@@ -62,7 +62,7 @@ test.cb("Mock File System – Read file", t => {
 
 	let fileSystem = { "/directory/helloWorldWriting.txt": a };
 
-	run(
+	run([
 		interpretMockFileSystem({
 			fileSystemRoot: directory,
 			startingFileSystem: fileSystem,
@@ -70,7 +70,7 @@ test.cb("Mock File System – Read file", t => {
 				fileSystem = newFileSystem;
 			},
 		}),
-	)(b => {
+	])(b => {
 		t.is(b, a);
 		t.end();
 	})(application);
@@ -81,11 +81,11 @@ test.cb("Mock File System – Write file", t => {
 	const fileName = "./helloWorldWriting.txt";
 	const directory = "/directory";
 
-	const application = writeFile(fileName, a);
+	const application = writeFile(fileName)(a);
 
 	let fileSystem: { [string]: string } = {};
 
-	run(
+	run([
 		interpretMockFileSystem({
 			fileSystemRoot: directory,
 			startingFileSystem: fileSystem,
@@ -93,7 +93,7 @@ test.cb("Mock File System – Write file", t => {
 				fileSystem = newFileSystem;
 			},
 		}),
-	)(() => {
+	])(() => {
 		t.is(fileSystem["/directory/helloWorldWriting.txt"], a);
 		t.end();
 	})(application);

--- a/sources/input.test.js
+++ b/sources/input.test.js
@@ -13,7 +13,7 @@ test.cb("Get character", t => {
 
 	const readableStream = new Readable();
 
-	run(interpretInput(readableStream))(readCharacter => {
+	run([interpretInput(readableStream)])(readCharacter => {
 		t.is(readCharacter, character);
 		t.end();
 	})(application);

--- a/sources/output.test.js
+++ b/sources/output.test.js
@@ -20,7 +20,7 @@ test.cb("Put string", t => {
 
 	const application = putString(stringToWrite);
 
-	run(interpretOutput(writableStream))(() => {
+	run([interpretOutput(writableStream)])(() => {
 		t.is(writtenString, stringToWrite);
 		t.end();
 	})(application);
@@ -40,7 +40,7 @@ test.cb("Put string line", t => {
 
 	const application = putStringLine(stringToWrite);
 
-	run(interpretOutput(writableStream))(() => {
+	run([interpretOutput(writableStream)])(() => {
 		t.is(writtenString, stringToWrite + "\n");
 		t.end();
 	})(application);

--- a/sources/reader.test.js
+++ b/sources/reader.test.js
@@ -10,7 +10,7 @@ test.cb("Get", t => {
 
 	const application = get();
 
-	run(interpretReader(character))(readData => {
+	run([interpretReader(character)])(readData => {
 		t.is(readData, character);
 		t.end();
 	})(application);

--- a/sources/readme.test.js
+++ b/sources/readme.test.js
@@ -1,0 +1,78 @@
+/* @flow */
+
+import test from "ava";
+import fs from "fs";
+import path from "path";
+
+import { FileSystem, run } from "./index.js";
+import { tempDirectory } from "./testUtils.js";
+
+// Note: These tests are used to ensure that the examples in the README always work
+
+test.cb("Real file system", t => {
+	const a = "Hello, World! I'm reading!";
+	const b = a.toUpperCase();
+
+	tempDirectory((err, directory) => {
+		t.is(null, err);
+
+		fs.mkdir(path.join(directory, "/home/me"), { recursive: true }, err => {
+			t.is(null, err);
+
+			fs.writeFile(path.join(directory, "/home/me", "./a.txt"), a, {}, err => {
+				t.is(null, err);
+
+				// Below this line comes mostly from the README
+
+				const upperCase = str => str.toUpperCase();
+
+				const application = FileSystem.readFile("./a.txt")
+					.map(upperCase)
+					.chain(FileSystem.writeFile("./b.txt"));
+
+				run([
+					FileSystem.interpretLocalFileSystem(path.join(directory, "/home/me")),
+				])(() => {
+					fs.readFile(
+						path.join(directory, "/home/me", "./b.txt"),
+						"utf8",
+						(err, bFile) => {
+							t.is(null, err);
+
+							t.is(bFile, b);
+							t.end();
+						},
+					);
+				})(application);
+			});
+		});
+	});
+});
+
+test.cb("Mock file system", t => {
+	const a = "hello, world";
+	const b = a.toUpperCase();
+
+	// Below this line comes mostly from the README
+
+	const upperCase = str => str.toUpperCase();
+
+	const application = FileSystem.readFile("./a.txt")
+		.map(upperCase)
+		.chain(FileSystem.writeFile("./b.txt"));
+
+	let fileSystem: { [string]: string } = { "/home/me/a.txt": "hello, world" };
+
+	run([
+		FileSystem.interpretMockFileSystem({
+			fileSystemRoot: "/home/me",
+			startingFileSystem: fileSystem,
+			onUpdate: newFileSystem => {
+				fileSystem = newFileSystem;
+			},
+		}),
+	])(() => {
+		t.is(fileSystem["/home/me/b.txt"], b);
+		t.end();
+	})(application);
+});

--- a/sources/state.test.js
+++ b/sources/state.test.js
@@ -10,7 +10,7 @@ test.cb("Get", t => {
 
 	const application = get();
 
-	run(interpretState(state))(receivedState => {
+	run([interpretState(state)])(receivedState => {
 		t.is(receivedState, state);
 		t.end();
 	})(application);
@@ -22,7 +22,7 @@ test.cb("Modify", t => {
 
 	const application = modify(modification).chain(get);
 
-	run(interpretState(state))(receivedState => {
+	run([interpretState(state)])(receivedState => {
 		t.is(receivedState, modification(state));
 		t.end();
 	})(application);
@@ -34,7 +34,7 @@ test.cb("Put", t => {
 
 	const application = put(newState).chain(get);
 
-	run(interpretState(state))(receivedState => {
+	run([interpretState(state)])(receivedState => {
 		t.is(receivedState, newState);
 		t.end();
 	})(application);


### PR DESCRIPTION
This pull request adds tests for the README example. It also adds a mock file system interpreter and updates function definitions for `run` and `FileSystem.writeFile`.